### PR TITLE
Rota /evadidos/{id} adicionada, configuração inicial do Swagger e estatísticas de egressos adicionadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Para instalar o livereload, para reinicio autómatico do servidor após atualiza
 pip install livereload
 ```
 
+## Documentação da API
+
+Para instalar a biblioteca que gerencia a documentação da API, digite:
+```
+pip install flask_swagger_ui
+```
+Para visualizar a documentação da API, basta acessar a rota **/swagger**
+
 ## Execução da aplicação
 
 Após instalar todas as dependências, para executar a aplicação basta executar o seguinte comando na raiz do projeto

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,4 +1,5 @@
 from flask import Blueprint
+
 routes = Blueprint('routes', __name__)
 
 from .statistics_controller import *

--- a/controllers/statistics_controller.py
+++ b/controllers/statistics_controller.py
@@ -8,11 +8,44 @@ from util import constants
 
 connection = Connection()
 
-# Rota responsável por retornar o número de alunos evadidos do curso de Computação agrupados
-#por período, onde o id_motivo deve ser um valor entre 1 e 9, inclusive.
+# função que retorna estatísticas sobre os egressos, informações como o total de graduados
+#em um determinado intervalo de tempo, média de graduados, períodos que tiveram mais e menos
+#graduados e seus números, respectivamente.
+def get_statistics(results):
+  total_graduados = 0
+  media_graduados = 0
+  periodo_max_graduados = results[0][0]
+  periodo_min_graduados = results[0][0]
+  max_graduados = results[0][1]
+  min_graduados = results[0][1]
+  for i in range(len(results)):
+    if (results[i][1] < min_graduados):
+      periodo_min_graduados = results[i][0]
+      min_graduados = results[i][1]
+    elif (results[i][1] > max_graduados):
+      periodo_max_graduados = results[i][0]
+      max_graduados = results[i][1]
+    total_graduados += results[i][1]
+
+  media_graduados = total_graduados / len(results)
+
+  return [total_graduados, round(media_graduados, 2), periodo_min_graduados, 
+    periodo_max_graduados, min_graduados, max_graduados]
+
+# função que monta a estrutura json para os alunos egressos (graduados), retorna um 
+#array de objetos, onde cada objeto contém o semestre de vínculo e a quantidade de
+#egressos daquele período.
+def formatter_graduates(periods):
+  response = []
+  for i in range(len(periods)):
+    response.append({"semestre_vinculo": periods[i][0], "qtd_egressos": periods[i][1]})
+  return response
+
+# Rota responsável por retornar o número de alunos evadidos do curso de Computação 
+#agrupados por período, onde o id_motivo deve ser um valor entre 1 e 9, inclusive.
 @routes.route("/evadidos/<int:id_motivo>")
 def escaped_from_periodo(id_motivo):
-  if id_motivo >= 1 and id_motivo <= 9:
+  if (id_motivo >= 1 and id_motivo <= 9):
     query = 'SELECT semestre_vinculo, count(*) AS qtd_evadidos\
       FROM "DiscenteVinculo"\
       WHERE id_curso=' + str(constants.COMPUTACAO_KEY) + \
@@ -27,10 +60,10 @@ def escaped_from_periodo(id_motivo):
 
     return jsonify(response)
   else:
-    return { "error": "Invalid resource" }
+    return { "error": "Invalid resource" }, 404
 
 # Rota responsável por retornar o número de alunos egressos (formados) do curso de 
-#Computação agrupados por período.
+#Computação e suas estatísticas de todos os períodos.
 @routes.route("/egressos")
 def graduates_by_period():
   query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\
@@ -39,34 +72,34 @@ def graduates_by_period():
     ' AND id_situacao_vinculo=' + str(constants.GRADUADO) + '\
     GROUP BY semestre_vinculo\
     ORDER BY semestre_vinculo'
+
   result = connection.select(query)
+  statistics = get_statistics(result)
 
-  response = []
-  for i in range(len(result)):
-    response.append({ "semestre_vinculo": result[i][0], "qtd_egressos": result[i][1] })
+  return jsonify(total_graduados=statistics[0], media_graduados=statistics[1], 
+    periodo_min_graduados=statistics[2], periodo_max_graduados=statistics[3], 
+    min_graduados=statistics[4], max_graduados=statistics[5], periodos=formatter_graduates(result))
 
-  return jsonify(response)
-
+# Rota responsável por retornar o número de alunos egressos (formados) do curso
+#de Computação, a partir de um intervalo definido de períodos e retornar também
+#suas estatísticas.
 @routes.route("/egressos/<minimo>/<maximo>")
-def graduates_by_interval_of_periods(maximo, minimo):
+def graduates_by_interval_of_periods(minimo, maximo):
+  if (minimo > maximo):
+    return { "error": "Parameters or invalid request" }, 404
+
   query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\
     FROM "DiscenteVinculo"\
     WHERE id_curso=' + str(constants.COMPUTACAO_KEY) + \
-    ' AND id_situacao_vinculo=' + str(constants.GRADUADO) + '\
+    'AND id_situacao_vinculo=' + str(constants.GRADUADO) + \
+    'AND semestre_vinculo BETWEEN \'' + str(minimo) + '\' AND \'' + str(maximo) + '\'\
     GROUP BY semestre_vinculo\
     ORDER BY semestre_vinculo'
+
   result = connection.select(query)
-  
-  min_index = 0
-  max_index = 0
-  for i in range(len(result)):
-    if (result[i][0] == minimo):
-      min_index = i
-    elif (result[i][0] == maximo):
-      max_index = i
+  statistics = get_statistics(result)
 
-  result_splitted = result[min_index:max_index+1]
-
-  print (result_splitted)
-
-  return { "min_index": min_index, "max_index": max_index }
+  return jsonify(total_graduados=statistics[0], media_graduados=statistics[1], 
+    periodo_min_graduados=statistics[2], periodo_max_graduados=statistics[3],
+    min_graduados=statistics[4], max_graduados=statistics[5], 
+    periodos=formatter_graduates(result))

--- a/controllers/statistics_controller.py
+++ b/controllers/statistics_controller.py
@@ -9,6 +9,22 @@ from util import constants
 
 connection = Connection()
 
+@routes.route("/evadidos/<int:id_motivo>")
+def escaped_from_periodo(id_motivo):
+  query = 'SELECT semestre_vinculo, count(*) AS qtd_evadidos\
+    FROM "DiscenteVinculo"\
+    WHERE id_curso=' + str(constants.COMPUTACAO_KEY) + \
+    ' AND id_situacao_vinculo=' + str(id_motivo) + '\
+    GROUP BY semestre_vinculo\
+    ORDER BY semestre_vinculo'
+  result = connection.select(query)
+
+  response = []
+  for i in range(len(result)):
+    response.append({ "semestre_vinculo": result[i][0], "qtd_evadidos": result[i][1] })
+
+  return jsonify(response)
+
 @routes.route("/egressos")
 def graduates_by_period():
   query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\

--- a/controllers/statistics_controller.py
+++ b/controllers/statistics_controller.py
@@ -2,12 +2,11 @@
 import sys
 sys.path.append("./connection")
 from Connection import Connection
-from flask import jsonify
+from flask import jsonify, request
 from . import routes
 from util import constants
 
 connection = Connection()
-
 
 # Rota responsável por retornar o número de alunos evadidos do curso de Computação agrupados
 #por período, onde o id_motivo deve ser um valor entre 1 e 9, inclusive.
@@ -30,7 +29,6 @@ def escaped_from_periodo(id_motivo):
   else:
     return { "error": "Invalid resource" }
 
-
 # Rota responsável por retornar o número de alunos egressos (formados) do curso de 
 #Computação agrupados por período.
 @routes.route("/egressos")
@@ -48,3 +46,27 @@ def graduates_by_period():
     response.append({ "semestre_vinculo": result[i][0], "qtd_egressos": result[i][1] })
 
   return jsonify(response)
+
+@routes.route("/egressos/<minimo>/<maximo>")
+def graduates_by_interval_of_periods(maximo, minimo):
+  query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\
+    FROM "DiscenteVinculo"\
+    WHERE id_curso=' + str(constants.COMPUTACAO_KEY) + \
+    ' AND id_situacao_vinculo=' + str(constants.GRADUADO) + '\
+    GROUP BY semestre_vinculo\
+    ORDER BY semestre_vinculo'
+  result = connection.select(query)
+  
+  min_index = 0
+  max_index = 0
+  for i in range(len(result)):
+    if (result[i][0] == minimo):
+      min_index = i
+    elif (result[i][0] == maximo):
+      max_index = i
+
+  result_splitted = result[min_index:max_index+1]
+
+  print (result_splitted)
+
+  return { "min_index": min_index, "max_index": max_index }

--- a/controllers/statistics_controller.py
+++ b/controllers/statistics_controller.py
@@ -8,23 +8,27 @@ from util import constants
 
 connection = Connection()
 
-# função que retorna estatísticas sobre os egressos, informações como o total de graduados
-#em um determinado intervalo de tempo, média de graduados, períodos que tiveram mais e menos
-#graduados e seus números, respectivamente.
+# Função que retorna estatísticas sobre os egressos, informações como o total de graduados
+## em um determinado intervalo de tempo, média de graduados, períodos que tiveram mais e menos
+### graduados e seus números, respectivamente.
 def get_statistics(results):
+
   total_graduados = 0
   media_graduados = 0
   periodo_max_graduados = results[0][0]
   periodo_min_graduados = results[0][0]
   max_graduados = results[0][1]
   min_graduados = results[0][1]
+
   for i in range(len(results)):
     if (results[i][1] < min_graduados):
       periodo_min_graduados = results[i][0]
       min_graduados = results[i][1]
+
     elif (results[i][1] > max_graduados):
       periodo_max_graduados = results[i][0]
       max_graduados = results[i][1]
+
     total_graduados += results[i][1]
 
   media_graduados = total_graduados / len(results)
@@ -32,17 +36,19 @@ def get_statistics(results):
   return [total_graduados, round(media_graduados, 2), periodo_min_graduados, 
     periodo_max_graduados, min_graduados, max_graduados]
 
-# função que monta a estrutura json para os alunos egressos (graduados), retorna um 
-#array de objetos, onde cada objeto contém o semestre de vínculo e a quantidade de
-#egressos daquele período.
+
+# Função que monta a estrutura json para os alunos egressos (graduados), retorna um
+## array de objetos, onde cada objeto contém o semestre de vínculo e a quantidade de
+### egressos daquele período.
 def formatter_graduates(periods):
   response = []
   for i in range(len(periods)):
     response.append({"semestre_vinculo": periods[i][0], "qtd_egressos": periods[i][1]})
   return response
 
+
 # Rota responsável por retornar o número de alunos evadidos do curso de Computação 
-#agrupados por período, onde o id_motivo deve ser um valor entre 1 e 9, inclusive.
+## agrupados por período, onde o id_motivo deve ser um valor entre 1 e 9, inclusive.
 @routes.route("/evadidos/<int:id_motivo>")
 def escaped_from_periodo(id_motivo):
   if (id_motivo >= 1 and id_motivo <= 9):
@@ -52,6 +58,7 @@ def escaped_from_periodo(id_motivo):
       ' AND id_situacao_vinculo=' + str(id_motivo) + '\
       GROUP BY semestre_vinculo\
       ORDER BY semestre_vinculo'
+
     result = connection.select(query)
 
     response = []
@@ -59,11 +66,13 @@ def escaped_from_periodo(id_motivo):
       response.append({ "semestre_vinculo": result[i][0], "qtd_evadidos": result[i][1] })
 
     return jsonify(response)
+
   else:
     return { "error": "Invalid resource" }, 404
 
+
 # Rota responsável por retornar o número de alunos egressos (formados) do curso de 
-#Computação e suas estatísticas de todos os períodos.
+## Computação e suas estatísticas de todos os períodos.
 @routes.route("/egressos")
 def graduates_by_period():
   query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\
@@ -80,9 +89,10 @@ def graduates_by_period():
     periodo_min_graduados=statistics[2], periodo_max_graduados=statistics[3], 
     min_graduados=statistics[4], max_graduados=statistics[5], periodos=formatter_graduates(result))
 
+
 # Rota responsável por retornar o número de alunos egressos (formados) do curso
-#de Computação, a partir de um intervalo definido de períodos e retornar também
-#suas estatísticas.
+## de Computação, a partir de um intervalo definido de períodos e retornar também
+### suas estatísticas.
 @routes.route("/egressos/<minimo>/<maximo>")
 def graduates_by_interval_of_periods(minimo, maximo):
   if (minimo > maximo):

--- a/controllers/statistics_controller.py
+++ b/controllers/statistics_controller.py
@@ -4,27 +4,35 @@ sys.path.append("./connection")
 from Connection import Connection
 from flask import jsonify
 from . import routes
-
 from util import constants
 
 connection = Connection()
 
+
+# Rota responsável por retornar o número de alunos evadidos do curso de Computação agrupados
+#por período, onde o id_motivo deve ser um valor entre 1 e 9, inclusive.
 @routes.route("/evadidos/<int:id_motivo>")
 def escaped_from_periodo(id_motivo):
-  query = 'SELECT semestre_vinculo, count(*) AS qtd_evadidos\
-    FROM "DiscenteVinculo"\
-    WHERE id_curso=' + str(constants.COMPUTACAO_KEY) + \
-    ' AND id_situacao_vinculo=' + str(id_motivo) + '\
-    GROUP BY semestre_vinculo\
-    ORDER BY semestre_vinculo'
-  result = connection.select(query)
+  if id_motivo >= 1 and id_motivo <= 9:
+    query = 'SELECT semestre_vinculo, count(*) AS qtd_evadidos\
+      FROM "DiscenteVinculo"\
+      WHERE id_curso=' + str(constants.COMPUTACAO_KEY) + \
+      ' AND id_situacao_vinculo=' + str(id_motivo) + '\
+      GROUP BY semestre_vinculo\
+      ORDER BY semestre_vinculo'
+    result = connection.select(query)
 
-  response = []
-  for i in range(len(result)):
-    response.append({ "semestre_vinculo": result[i][0], "qtd_evadidos": result[i][1] })
+    response = []
+    for i in range(len(result)):
+      response.append({ "semestre_vinculo": result[i][0], "qtd_evadidos": result[i][1] })
 
-  return jsonify(response)
+    return jsonify(response)
+  else:
+    return { "error": "Invalid resource" }
 
+
+# Rota responsável por retornar o número de alunos egressos (formados) do curso de 
+#Computação agrupados por período.
 @routes.route("/egressos")
 def graduates_by_period():
   query = 'SELECT semestre_vinculo, count(*) AS qtd_egressos\

--- a/run.py
+++ b/run.py
@@ -1,10 +1,24 @@
 from livereload import Server
 from controllers import *
 from flask import Flask
+from flask_swagger_ui import get_swaggerui_blueprint
 
 app = Flask(__name__)
 
 app.register_blueprint(routes)
+
+### Swagger specific 
+SWAGGER_URL = '/swagger'
+API_URL = '/static/swagger.json'
+SWAGGERUI_BLUEPRINT = get_swaggerui_blueprint(
+  SWAGGER_URL,
+  API_URL,
+  config={
+    'app-name': "PDC Backend"
+  }
+)
+app.register_blueprint(SWAGGERUI_BLUEPRINT, url_prefix=SWAGGER_URL)
+### end Swagger specific
 
 if __name__ == '__main__':
   server = Server(app.wsgi_app)

--- a/static/swagger.json
+++ b/static/swagger.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Computação@UFCG",
+    "version": "1.0.0",
+    "title": "Painel de Controle - Backend",
+    "contact": {
+      "email": ""
+    },
+    "license": {
+      "name": "GNU - General Public License",
+      "url": "https://opensource.org/licenses/gpl-license"
+    }
+  }
+}


### PR DESCRIPTION
Adicionado endpoint **/evadidos/{id}** que retorna a quantidade de alunos evadidos do curso pelo motivo {id}, que refere-se ao motivo de cancelamento da matrícula, números que estes que podem ser de 1 a 9, inclusive.

Configurei inicialmente o Swagger para documentação das rotas, mas ele ainda está vazio, pois pelo que pesquisei as rotas devem ser adicionadas manualmente a um arquivo swagger.json. Irei fazer isso posteriormente, mas já é possível acessar a interface do Swagger a partir do endpoint **/swagger**.

Também adicionei as estatísticas de egressos ao retorno do json das rotas **/egressos** e **/egressos/periodo-ini/periodo-fim**, que retornam informações como a quantidade de formados no intervalo especificado, média de formados, período com mais e menos egressos, respectivamente, e também seus números de egressos.

A rota **/egressos** retorna a quantidade de egressos de todos os períodos até então cadastrados no BD, e também as estatísticas considerando todos os períodos.
Já a rota **/egressos/periodo-ini/periodo-fim** retorna a quantidade de egressos no intervalo especificado, exemplo: a chamada na rota **/egressos/1984.1/2019.2** irá retornar o número de egressos agrupados por período de 1984.1 até 2019.2, além de também suas estatísticas.